### PR TITLE
fix: correct argument key for subscription update params

### DIFF
--- a/lib/src/adapty.dart
+++ b/lib/src/adapty.dart
@@ -256,7 +256,7 @@ class Adapty {
       },
       {
         Argument.product: product.jsonValue,
-        if (subscriptionUpdateParams != null) Argument.params: subscriptionUpdateParams.jsonValue,
+        if (subscriptionUpdateParams != null) Argument.subscriptionUpdateParams: subscriptionUpdateParams.jsonValue,
         if (isOfferPersonalized != null) Argument.isOfferPersonalized: isOfferPersonalized,
       },
     );

--- a/lib/src/constants/argument.dart
+++ b/lib/src/constants/argument.dart
@@ -7,6 +7,7 @@ class Argument {
 
   static const String value = 'value';
   static const String params = 'params';
+  static const String subscriptionUpdateParams = 'subscription_update_params';
 
   static const String id = 'id';
   static const String placementId = 'placement_id';


### PR DESCRIPTION
On the Android platform, `AdaptySubscriptionUpdateParams` has no effect due to the incorrect JSON key.

- Updated `Argument.params` to `Argument.subscriptionUpdateParams` in `lib/src/adapty.dart`
- Added `subscriptionUpdateParams` constant in `lib/src/constants/argument.dart`