### PR TITLE
fix(ios): resolve FlutterViewController via UIScene and walk VC tree

### DIFF
--- a/ios/Classes/SwiftAdaptyPaywallNativeView.swift
+++ b/ios/Classes/SwiftAdaptyPaywallNativeView.swift
@@ -118,9 +118,32 @@ class AdaptyPaywallNativeView: NSObject, FlutterPlatformView {
 }
 
 extension UIApplication {
+    @MainActor
     func flutterCanvasViewController() -> FlutterViewController? {
-        UIApplication.shared.windows
-            .first(where: { $0.isKeyWindow })?
-            .rootViewController as? FlutterViewController
+        // Resolve via UIScene (UIApplication.shared.windows is deprecated and
+        // returns differently under iOS 26 SDK linkage) and walk the VC tree
+        // so add-to-app hosts (Flutter inside a UIKit/SwiftUI container) work.
+        let scene = connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first { $0.activationState == .foregroundActive }
+        guard let root = scene?.windows.first(where: { $0.isKeyWindow })?.rootViewController else {
+            return nil
+        }
+        return Self.findFlutterViewController(in: root)
+    }
+
+    @MainActor
+    private static func findFlutterViewController(in vc: UIViewController) -> FlutterViewController? {
+        if let flutter = vc as? FlutterViewController { return flutter }
+        // Check presented before children: a Flutter VC presented modally over
+        // a UIKit host should win over a stale embedded one deeper in the tree.
+        if let presented = vc.presentedViewController,
+           let found = findFlutterViewController(in: presented) {
+            return found
+        }
+        for child in vc.children {
+            if let found = findFlutterViewController(in: child) { return found }
+        }
+        return nil
     }
 }


### PR DESCRIPTION
## Problem

`UIApplication.flutterCanvasViewController()` uses `UIApplication.shared.windows`, which has been deprecated since iOS 15. On binaries linked against the iOS 26 SDK Apple changed the runtime behavior, for scene-based apps it no longer returns the key window. The lookup returns `nil`, `AdaptyPaywallNativeView.createNativeView` throws `platformViewError("Flutter Canvas Controller Not Found")`, the `catch` falls into `// TODO: draw error state`, and the embedded paywall renders as a blank canvas.

The same lookup additionally assumes Flutter is the window's `rootViewController`, so any Flutter add-to-app host that embeds `FlutterViewController` inside a UIKit/SwiftUI container also fails, even on older SDKs, because the cast `rootViewController as? FlutterViewController` returns nil.

## Fix

- Use `UIApplication.connectedScenes` to find the foreground-active `UIWindowScene`, then its key window's `rootViewController`. Avoids the deprecated `UIApplication.shared.windows` entirely.
- Walk the view-controller tree (presented first, then children) so the `FlutterViewController` is found anywhere in the hierarchy, not only at the window root.
- `@MainActor` on both methods so Swift surfaces off-main misuse at compile time instead of tripping the UIKit main-thread checker at runtime.
- Fail clean (return `nil`) if no foreground-active scene exists or no window in that scene is key, rather than silently falling back to an arbitrary scene/window.

## Verification

Reproduced in a Flutter add-to-app build (`FlutterViewController` nested inside SwiftUI `UIHostingController`) on iPhone 17 Pro running iOS 26.5, compiled against iPhoneOS 26.5 SDK (`LC_BUILD_VERSION sdk 26.5`):

- Unpatched 3.15.5: paywall renders blank ("Flutter Canvas Controller Not Found").
- Same source built with this patch: paywall renders correctly against the same Adapty backend.

`LC_BUILD_VERSION sdk 26.5` is unchanged between the two builds, isolating the variable to the lookup code (deprecated-API gating) and ruling out other SDK/Xcode/environment differences.

## Known limitations not addressed here

The lookup is still global rather than scoped to the engine that issued the platform-view creation. In apps with `FlutterEngineGroup` and multiple `FlutterViewController` instances, the walk returns the first one found rather than the one owning this platform view. A deeper fix would resolve the host from the `FlutterEngine` passed to the factory's `binaryMessenger`, or via the responder chain from the platform view itself (`view.next`). Out of scope here, happy to follow up if you prefer either approach.
