### PR TITLE
fix(android): compile plugin at JVM 11 so the 3.17.x native SDK inlines

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,12 +25,12 @@ android {
     compileSdk = 34
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
 
     sourceSets {


### PR DESCRIPTION
### Problem

`adapty_flutter` 3.17.x compiles its native Android plugin at `jvmTarget = '1.8'`, but the native Adapty Android SDK it now depends on (`io.adapty:android-ui` via `adapty-bom` 3.17.1) is built for **JVM target 11** and exposes `inline` functions used by `AdaptyPaywallNativeView` / `AdaptyOnboardingNativeView`. Kotlin refuses to inline JVM-11 bytecode into a JVM-1.8 target, so any consumer's `flutter build aar` / app build fails at `:adapty_flutter:compile{Debug,Release}Kotlin`:

```
Cannot inline bytecode built with JVM target 11 into bytecode that is being
built with JVM target 1.8. Please specify proper '-jvm-target' option.
```

This is the issue reported in #189.

### Fix

Raise the plugin's `compileOptions` (`sourceCompatibility` / `targetCompatibility`) and `kotlinOptions.jvmTarget` from `1.8` to `11` in `android/build.gradle` — exactly the workaround the Adapty team already posted in #189, now applied at the source so consumers don't have to patch their pub cache.

```diff
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }

     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
```

JVM 11 is already the floor for the AGP/Gradle and native SDK in use here, so this doesn't raise the effective requirement for consumers — it only aligns the plugin's own compile target with the bytecode it links against.

### Verification

Applied this change as a fork override in our app (Blokada) and confirmed it resolves the `compileReleaseKotlin` inline failure, with paywall / purchase / restore / onboarding validated on-device against `adapty_flutter` 3.17 + `adapty-bom` 3.17.1.

Fixes #189
