### PR TITLE
Enable removal of PaywallEventsObserver callback

### DIFF
--- a/lib/src/adaptyui.dart
+++ b/lib/src/adaptyui.dart
@@ -33,7 +33,7 @@ class AdaptyUI {
   }
 
   /// Use this method to set the AdaptyUI paywalls events observer.
-  void setPaywallsEventsObserver(AdaptyUIPaywallsEventsObserver observer) {
+  void setPaywallsEventsObserver(AdaptyUIPaywallsEventsObserver? observer) {
     AdaptyLogger.write(AdaptyLogLevel.verbose, 'AdaptyUI.setPaywallsEventsObserver()');
     _eventsProxy.paywallsEventsObserver = observer;
   }


### PR DESCRIPTION
In the integration example (https://adapty.io/docs/flutter-quickstart-paywalls#full-example) a `StatefulWidget` is registered as a paywall event observer with `AdaptyUI().setPaywallsEventsObserver(this);`, creating a reference to object.

However, no method to clear such registration is given, forcing the library to keep the `Widget` alive (via ref count).
This PR modifies the `setPaywallsEventObserver` by enabling the callback to be null, thus enabling cleanup actions.