### PR TITLE
fix(example): request the flow locale at runtime, post-4.1 doc follow-ups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ Public exports are controlled via `lib/adapty_flutter.dart` using explicit `show
 
 ### Event System
 
-Observer interfaces (`AdaptyUIPaywallsEventsObserver`, `AdaptyUIOnboardingsEventsObserver`) in `lib/src/adaptyui_observer.dart` handle native→Dart callbacks. Event routing goes through `lib/src/adaptyui_events_proxy.dart`. Profile updates use a broadcast `StreamController`.
+Observer interfaces (`AdaptyUIFlowsEventsObserver`, `AdaptyUIOnboardingsEventsObserver`) in `lib/src/adaptyui_observer.dart` handle native→Dart callbacks. Event routing goes through `lib/src/adaptyui_events_proxy.dart`. Profile updates use a broadcast `StreamController`.
 
 ### Platform Views
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 4.1.0-dev.1
 
-> This development package is intentionally marked non-publishable; the version bump and the exact native pins happen at the release cut.
+> This development package is intentionally marked non-publishable; the version bump and the exact iOS pin happen at the release cut.
 
 Attribution APIs now use external-provider terminology consistently with Adapty iOS SDK 4.1.
 
@@ -18,13 +18,14 @@ The old public names have been removed rather than deprecated.
 - `AdaptyExternalAttributionProvider` provides `appleAds`, `adjust`, `appsflyer`, `branch`, `tenjin`, and `custom`. It remains an open string wrapper, so identifiers added by the backend in the future can be used without waiting for a Flutter SDK update.
 - `AdaptyUI.createFlowView` and `AdaptyUIFlowPlatformView` now accept a `customLayoutId` — the ID of a `flow.uiSchema.grids[*].customId` grid to render instead of the one resolved automatically for the current device. Pass `null` to keep the automatic selection. This is not `AdaptyFlowUiSchemaLayout.flowLayoutId`, which identifies a layout rather than a grid.
 - A blank `customLayoutId` is treated as `null` and surrounding whitespace is trimmed, so an empty or padded value falls back to the automatic grid selection instead of failing to match a grid.
-- [Android] The parameter reaches the native SDK starting from Android `4.1.0` (`crossplatform` `4.1.3`); the bundled dependency (`4.1.1` / `4.1.4`) supports it, so custom layouts work on both platforms.
 - An unknown grid ID fails `createFlowView` with an `AdaptyError`. In `AdaptyUIFlowPlatformView` the same failure leaves the embedded view empty and is only written to the native log.
 - In `AdaptyUIFlowPlatformView` the value, like every other creation parameter, is read once when the native view is created; changing it on a mounted widget has no effect.
 
 ### 📦 Native dependencies
 
 - [Android] Native Android SDK dependency bumped to `4.1.1` (`crossplatform` `4.1.4`). The renamed `update_external_attribution_data` request and the `adapty_attribution_enabled` flag are handled natively starting from Android `4.1.0`, so this package cannot run against an older native Android SDK.
+- [Android] `customLayoutId` reaches the native SDK starting from Android `4.1.0` (`crossplatform` `4.1.3`); the bundled dependency supports it, so custom layouts work on both platforms.
+- [iOS] The native iOS SDK dependency still tracks the `dev` branch; it is pinned to a tag at the release cut.
 
 # 4.0.4
 

--- a/example/README.md
+++ b/example/README.md
@@ -6,8 +6,9 @@ This app mirrors the iOS `AdaptyRecipes-SwiftUI` example:
 
 - free and premium recipe categories;
 - premium access check through the `premium` access level;
-- modal and embedded Adapty Flow presentation;
-- profile, login, logout, update, and restore actions.
+- modal and embedded Adapty Flow presentation, with the flow locale editable on the profile screen;
+- profile, login, logout, update, and restore actions;
+- an external attribution demo (`Send External Attribution` on the profile screen).
 
 Before running, replace the placeholders in `lib/app/app_constants.dart`:
 
@@ -15,6 +16,8 @@ Before running, replace the placeholders in `lib/app/app_constants.dart`:
 static const adaptyApiKey = 'YOUR_API_KEY';
 static const placementId = 'YOUR_PLACEMENT_ID';
 ```
+
+`flowLocale` in the same file is the initial locale for flow views (`null` = default); change it there or from the profile screen at runtime.
 
 Then run:
 

--- a/example/lib/app/app_adapty_service.dart
+++ b/example/lib/app/app_adapty_service.dart
@@ -19,7 +19,10 @@ abstract interface class AppAdaptyService {
 
   Future<AdaptyProfile> restorePurchases();
 
-  Future<void> updateExternalAttribution(Map<String, dynamic> attribution, {required AdaptyExternalAttributionProvider provider});
+  Future<void> updateExternalAttribution(
+    Map<String, dynamic> attribution, {
+    required AdaptyExternalAttributionProvider provider,
+  });
 }
 
 final class DefaultAppAdaptyService implements AppAdaptyService {
@@ -55,8 +58,10 @@ final class DefaultAppAdaptyService implements AppAdaptyService {
   Future<AdaptyProfile> restorePurchases() => _adapty.restorePurchases();
 
   @override
-  Future<void> updateExternalAttribution(Map<String, dynamic> attribution, {required AdaptyExternalAttributionProvider provider}) =>
-      _adapty.updateExternalAttribution(attribution, provider: provider);
+  Future<void> updateExternalAttribution(
+    Map<String, dynamic> attribution, {
+    required AdaptyExternalAttributionProvider provider,
+  }) => _adapty.updateExternalAttribution(attribution, provider: provider);
 }
 
 abstract interface class AppAdaptyUIService {

--- a/example/lib/app/app_constants.dart
+++ b/example/lib/app/app_constants.dart
@@ -6,7 +6,8 @@ abstract final class AppConstants {
   static const adaptyApiKey = 'YOUR_API_KEY';
   static const placementId = 'YOUR_PLACEMENT_ID';
 
-  /// The localization the flow views are built with, e.g. `en`, `es`, `fr`.
+  /// The initial localization for flow views, e.g. `en`, `es`, `fr`; it can be
+  /// changed at runtime on the profile screen.
   ///
   /// Starting with Adapty SDK 4.0.0 a flow is localized when its view is built,
   /// so the value goes to `AdaptyUI.createFlowView` / `AdaptyUIFlowPlatformView`
@@ -17,10 +18,7 @@ abstract final class AppConstants {
 
   /// Sample conversion data sent by the "Send External Attribution" row.
   /// A real app passes what its attribution SDK reports.
-  static const demoAttribution = <String, dynamic>{
-    'network': 'adapty_recipes',
-    'campaign': 'demo',
-  };
+  static const demoAttribution = <String, dynamic>{'network': 'adapty_recipes', 'campaign': 'demo'};
 
   static bool get hasValidConfiguration => isValidAdaptyApiKey(adaptyApiKey) && isValidPlacementId(placementId);
 

--- a/example/lib/app/app_controller.dart
+++ b/example/lib/app/app_controller.dart
@@ -42,6 +42,10 @@ class AppController extends ChangeNotifier {
   AdaptyProfile? profile;
   AdaptyFlow? flow;
 
+  /// The localization requested for the next flow view (modal or embedded).
+  /// `null` asks for the default; see [AppConstants.flowLocale].
+  String? requestedFlowLocale = AppConstants.flowLocale;
+
   /// The localization the most recent flow view was built with, as reported by
   /// `AdaptyUIFlowView.locale`. `null` until a view has been built.
   String? flowViewLocale;
@@ -234,7 +238,7 @@ class AppController extends ChangeNotifier {
       final currentFlow = flow ?? await _adapty.getFlow(placementId: AppConstants.placementId);
       flow = currentFlow;
 
-      final view = await _adaptyUI.createFlowView(flow: currentFlow, locale: AppConstants.flowLocale);
+      final view = await _adaptyUI.createFlowView(flow: currentFlow, locale: requestedFlowLocale);
       recordFlowView(view);
       final observer = _ModalFlowObserver(
         viewId: view.id,
@@ -257,6 +261,19 @@ class AppController extends ChangeNotifier {
 
   void applyProfileFromFlow(AdaptyProfile value) {
     _applyProfile(value);
+  }
+
+  /// Sets the localization for the next flow view. A blank value means the
+  /// default; surrounding whitespace is dropped.
+  void setRequestedFlowLocale(String? value) {
+    final trimmed = value?.trim();
+    final normalized = (trimmed == null || trimmed.isEmpty) ? null : trimmed;
+    if (normalized == requestedFlowLocale) {
+      return;
+    }
+
+    requestedFlowLocale = normalized;
+    notifyListeners();
   }
 
   /// Remembers the localization a flow view was built with. Called for the
@@ -329,6 +346,7 @@ class AppController extends ChangeNotifier {
     isReloadingProfile = false;
     isLoadingFlow = false;
     isRestoringPurchases = false;
+    isSendingAttribution = false;
     _setErrorIfOwned(errorOperation, null);
     notifyListeners();
   }

--- a/example/lib/app/app_controller.dart
+++ b/example/lib/app/app_controller.dart
@@ -35,6 +35,7 @@ class AppController extends ChangeNotifier {
   int _profileUpdateSequence = 0;
   int _flowRequestSequence = 0;
   int _restoreRequestSequence = 0;
+  int _attributionRequestSequence = 0;
   int _errorOperationSequence = 0;
 
   String? userId;
@@ -199,27 +200,35 @@ class AppController extends ChangeNotifier {
     }
 
     final revision = _identityRevision;
+    final request = ++_attributionRequestSequence;
     final errorOperation = _claimErrorOperation();
+    // A request that outlives an identity transition must not touch the flag
+    // or the banner: a newer request for the new identity may already own them.
+    bool ownsRequest() => _isCurrentRevision(revision) && request == _attributionRequestSequence;
+
     isSendingAttribution = true;
     _setErrorIfOwned(errorOperation, null);
     notifyListeners();
 
+    var sent = false;
     try {
       await _adapty.updateExternalAttribution(
         AppConstants.demoAttribution,
         provider: AdaptyExternalAttributionProvider.custom,
       );
+      sent = true;
     } catch (error) {
-      if (_isCurrentRevision(revision)) {
+      if (ownsRequest()) {
         _setErrorIfOwned(errorOperation, _contextualError('Attribution', error));
       }
-      return;
     } finally {
-      isSendingAttribution = false;
-      notifyListeners();
+      if (ownsRequest()) {
+        isSendingAttribution = false;
+        notifyListeners();
+      }
     }
 
-    if (_isCurrentRevision(revision)) {
+    if (sent && ownsRequest()) {
       await reloadProfile();
     }
   }
@@ -339,6 +348,7 @@ class AppController extends ChangeNotifier {
     _profileRequestSequence += 1;
     _flowRequestSequence += 1;
     _restoreRequestSequence += 1;
+    _attributionRequestSequence += 1;
     userId = newUserId;
     profile = null;
     flow = null;

--- a/example/lib/ui/embedded_flow_screen.dart
+++ b/example/lib/ui/embedded_flow_screen.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:adapty_flutter/adapty_flutter.dart';
 import 'package:flutter/material.dart';
 
-import '../app/app_constants.dart';
 import '../app/app_controller.dart';
 import 'adaptive.dart';
 
@@ -57,7 +56,7 @@ class _EmbeddedFlowScreenState extends State<EmbeddedFlowScreen> {
           children: [
             AdaptyUIFlowPlatformView(
               flow: flow,
-              locale: AppConstants.flowLocale,
+              locale: widget.controller.requestedFlowLocale,
               androidEnableSafeArea: true,
               onDidAppear: widget.controller.recordFlowView,
               onDidPerformAction: (view, action) {

--- a/example/lib/ui/profile_screen.dart
+++ b/example/lib/ui/profile_screen.dart
@@ -138,7 +138,8 @@ class ProfileScreen extends StatelessWidget {
                   title: controller.isSendingAttribution
                       ? 'Sending...'
                       : 'Send External Attribution',
-                  onTap: controller.canUseSdk && !controller.isSendingAttribution
+                  onTap:
+                      controller.canUseSdk && !controller.isSendingAttribution
                       ? controller.sendExternalAttribution
                       : null,
                   trailing: controller.isSendingAttribution
@@ -152,7 +153,9 @@ class ProfileScreen extends StatelessWidget {
               children: [
                 InfoRow(
                   title: 'Requested Locale',
-                  subtitle: AppConstants.flowLocale ?? 'Default (en)',
+                  subtitle: controller.requestedFlowLocale ?? 'Default (en)',
+                  trailing: _chevron(context),
+                  onTap: () => _showFlowLocaleDialog(context),
                 ),
                 InfoRow(
                   title: 'View Locale',
@@ -213,6 +216,20 @@ class ProfileScreen extends StatelessWidget {
         '${local.day.toString().padLeft(2, '0')} '
         '${local.hour.toString().padLeft(2, '0')}:'
         '${local.minute.toString().padLeft(2, '0')}';
+  }
+
+  Future<void> _showFlowLocaleDialog(BuildContext context) async {
+    final value = await showAdaptiveTextDialog(
+      context,
+      title: 'Flow Locale',
+      placeholder: 'Locale (e.g. en, es, fr) or blank',
+      initialValue: controller.requestedFlowLocale,
+    );
+    if (value == null) {
+      return;
+    }
+
+    controller.setRequestedFlowLocale(value);
   }
 
   Future<void> _showLoginDialog(BuildContext context) async {
@@ -313,36 +330,59 @@ class _PremiumStatusRow extends StatelessWidget {
 }
 
 Future<String?> showAdaptiveLoginDialog(BuildContext context) {
+  return showAdaptiveTextDialog(
+    context,
+    title: 'Log In',
+    placeholder: 'Enter user id',
+  );
+}
+
+/// Shows a platform-styled dialog with a single text field and returns the
+/// entered text, or `null` when cancelled.
+Future<String?> showAdaptiveTextDialog(
+  BuildContext context, {
+  required String title,
+  required String placeholder,
+  String? initialValue,
+}) {
   if (usesCupertino) {
-    return _showCupertinoLoginDialog(context);
+    return showCupertinoDialog<String>(
+      context: context,
+      builder: (context) => _CupertinoTextDialog(
+        title: title,
+        placeholder: placeholder,
+        initialValue: initialValue,
+      ),
+    );
   }
 
-  return _showMaterialLoginDialog(context);
-}
-
-Future<String?> _showCupertinoLoginDialog(BuildContext context) async {
-  return showCupertinoDialog<String>(
-    context: context,
-    builder: (context) => const _CupertinoLoginDialog(),
-  );
-}
-
-Future<String?> _showMaterialLoginDialog(BuildContext context) async {
   return showDialog<String>(
     context: context,
-    builder: (context) => const _MaterialLoginDialog(),
+    builder: (context) => _MaterialTextDialog(
+      title: title,
+      placeholder: placeholder,
+      initialValue: initialValue,
+    ),
   );
 }
 
-class _CupertinoLoginDialog extends StatefulWidget {
-  const _CupertinoLoginDialog();
+class _CupertinoTextDialog extends StatefulWidget {
+  const _CupertinoTextDialog({
+    required this.title,
+    required this.placeholder,
+    this.initialValue,
+  });
+
+  final String title;
+  final String placeholder;
+  final String? initialValue;
 
   @override
-  State<_CupertinoLoginDialog> createState() => _CupertinoLoginDialogState();
+  State<_CupertinoTextDialog> createState() => _CupertinoTextDialogState();
 }
 
-class _CupertinoLoginDialogState extends State<_CupertinoLoginDialog> {
-  final _controller = TextEditingController();
+class _CupertinoTextDialogState extends State<_CupertinoTextDialog> {
+  late final _controller = TextEditingController(text: widget.initialValue);
 
   @override
   void dispose() {
@@ -353,12 +393,12 @@ class _CupertinoLoginDialogState extends State<_CupertinoLoginDialog> {
   @override
   Widget build(BuildContext context) {
     return CupertinoAlertDialog(
-      title: const Text('Log In'),
+      title: Text(widget.title),
       content: Padding(
         padding: const EdgeInsets.only(top: 12),
         child: CupertinoTextField(
           controller: _controller,
-          placeholder: 'Enter user id',
+          placeholder: widget.placeholder,
           autofocus: true,
         ),
       ),
@@ -376,15 +416,23 @@ class _CupertinoLoginDialogState extends State<_CupertinoLoginDialog> {
   }
 }
 
-class _MaterialLoginDialog extends StatefulWidget {
-  const _MaterialLoginDialog();
+class _MaterialTextDialog extends StatefulWidget {
+  const _MaterialTextDialog({
+    required this.title,
+    required this.placeholder,
+    this.initialValue,
+  });
+
+  final String title;
+  final String placeholder;
+  final String? initialValue;
 
   @override
-  State<_MaterialLoginDialog> createState() => _MaterialLoginDialogState();
+  State<_MaterialTextDialog> createState() => _MaterialTextDialogState();
 }
 
-class _MaterialLoginDialogState extends State<_MaterialLoginDialog> {
-  final _controller = TextEditingController();
+class _MaterialTextDialogState extends State<_MaterialTextDialog> {
+  late final _controller = TextEditingController(text: widget.initialValue);
 
   @override
   void dispose() {
@@ -395,10 +443,10 @@ class _MaterialLoginDialogState extends State<_MaterialLoginDialog> {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: const Text('Log In'),
+      title: Text(widget.title),
       content: TextField(
         controller: _controller,
-        decoration: const InputDecoration(labelText: 'Enter user id'),
+        decoration: InputDecoration(labelText: widget.placeholder),
         autofocus: true,
       ),
       actions: [

--- a/example/test/app_constants_test.dart
+++ b/example/test/app_constants_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 
-import '../lib/app/app_constants.dart';
+import 'package:adapty_recipes/app/app_constants.dart';
 
 void main() {
   group('AppConstants configuration validation', () {

--- a/example/test/app_controller_test.dart
+++ b/example/test/app_controller_test.dart
@@ -178,6 +178,39 @@ void main() {
     expect(controller.isSendingAttribution, isFalse);
   });
 
+  test('a stale attribution request cannot clear the flag of a newer one after an identity switch', () async {
+    await seedOldState();
+    final first = Completer<void>();
+    final second = Completer<void>();
+    var calls = 0;
+    adapty.updateExternalAttributionHandler = (_, __) => (++calls == 1 ? first : second).future;
+
+    final staleRequest = controller.sendExternalAttribution();
+    await pumpEventQueue();
+    await controller.login('new-user');
+    expect(controller.isSendingAttribution, isFalse);
+
+    final newRequest = controller.sendExternalAttribution();
+    await pumpEventQueue();
+    expect(controller.isSendingAttribution, isTrue);
+    expect(adapty.updateExternalAttributionCalls, 2);
+
+    first.complete();
+    await staleRequest;
+    expect(controller.isSendingAttribution, isTrue, reason: 'the stale request must not clear the active flag');
+
+    await controller.sendExternalAttribution();
+    expect(
+      adapty.updateExternalAttributionCalls,
+      2,
+      reason: 'a third request must be rejected while the second is in flight',
+    );
+
+    second.complete();
+    await newRequest;
+    expect(controller.isSendingAttribution, isFalse);
+  });
+
   test('native identify failure retains the current identity state', () async {
     final old = await seedOldState();
     adapty.identifyHandler = (_) async => throw StateError('identify failed');

--- a/example/test/app_controller_test.dart
+++ b/example/test/app_controller_test.dart
@@ -1,23 +1,35 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:adapty_flutter/adapty_flutter.dart';
 import 'package:adapty_flutter/src/models/adapty_flow.dart' show AdaptyFlowJSONBuilder;
 import 'package:adapty_flutter/src/models/adapty_profile.dart' show AdaptyProfileJSONBuilder;
 import 'package:adapty_flutter/src/models/adaptyui/adaptyui_flow_view.dart' show AdaptyUIFlowViewJSONBuilder;
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../lib/app/app_adapty_service.dart';
-import '../lib/app/app_constants.dart';
-import '../lib/app/app_controller.dart';
-import '../lib/app/user_manager.dart';
+import 'package:adapty_recipes/app/app_adapty_service.dart';
+import 'package:adapty_recipes/app/app_constants.dart';
+import 'package:adapty_recipes/app/app_controller.dart';
+import 'package:adapty_recipes/app/user_manager.dart';
+
+/// `AdaptyUIFlowView.present()` goes straight to the SDK channel, so the
+/// modal-flow tests answer it here instead of letting it fail.
+const _channel = MethodChannel('flutter.adapty.com/adapty');
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   late _FakeAdaptyService adapty;
   late _FakeAdaptyUIService adaptyUI;
   late _FakeUserManager userManager;
   late AppController controller;
 
   setUp(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      _channel,
+      (call) async => jsonEncode({'success': null}),
+    );
     adapty = _FakeAdaptyService();
     adaptyUI = _FakeAdaptyUIService();
     userManager = _FakeUserManager();
@@ -27,6 +39,7 @@ void main() {
   });
 
   tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(_channel, null);
     controller.dispose();
     await adapty.dispose();
   });
@@ -57,15 +70,65 @@ void main() {
     expect(fresh.errorMessage, isNull);
   });
 
-  test('modal flow view is built with the configured locale and records the resolved one', () async {
+  test('modal flow view is built with the requested locale and records the resolved one', () async {
     adapty.getFlowHandler = () async => _flow('flow');
     adaptyUI.createFlowViewHandler = () async => _flowView(locale: 'fr');
+    controller.setRequestedFlowLocale('fr');
 
     await controller.presentFlowModally();
 
     expect(adaptyUI.createFlowViewCalls, 1);
-    expect(adaptyUI.lastLocale, AppConstants.flowLocale);
+    expect(adaptyUI.lastLocale, 'fr');
     expect(controller.flowViewLocale, 'fr');
+    expect(controller.errorMessage, isNull);
+    expect(controller.isPresentingFlow, isFalse);
+  });
+
+  test('setRequestedFlowLocale trims the value and maps blank to the default', () {
+    var notifications = 0;
+    controller.addListener(() => notifications += 1);
+
+    controller.setRequestedFlowLocale('  es ');
+    controller.setRequestedFlowLocale('es');
+    controller.setRequestedFlowLocale('   ');
+
+    expect(controller.requestedFlowLocale, isNull);
+    expect(notifications, 2);
+  });
+
+  test('sendExternalAttribution ignores a second tap while the first request is in flight', () async {
+    await seedOldState();
+    final pending = Completer<void>();
+    adapty.updateExternalAttributionHandler = (_, __) => pending.future;
+
+    final first = controller.sendExternalAttribution();
+    await pumpEventQueue();
+    expect(controller.isSendingAttribution, isTrue);
+
+    await controller.sendExternalAttribution();
+    expect(adapty.updateExternalAttributionCalls, 1);
+
+    pending.complete();
+    await first;
+    expect(controller.isSendingAttribution, isFalse);
+  });
+
+  test('identity transition clears the attribution flag and skips the stale profile reload', () async {
+    await seedOldState();
+    final pending = Completer<void>();
+    adapty.updateExternalAttributionHandler = (_, __) => pending.future;
+
+    final attribution = controller.sendExternalAttribution();
+    await pumpEventQueue();
+    await controller.login('new-user');
+    expect(controller.isSendingAttribution, isFalse);
+    final profileCallsAfterLogin = adapty.getProfileCalls;
+
+    pending.complete();
+    await attribution;
+
+    expect(controller.isSendingAttribution, isFalse);
+    expect(adapty.getProfileCalls, profileCallsAfterLogin);
   });
 
   test('recordFlowView stores the view locale and notifies once per change', () {
@@ -769,7 +832,10 @@ final class _FakeAdaptyService implements AppAdaptyService {
   void setupAfterHotRestart() {}
 
   @override
-  Future<void> updateExternalAttribution(Map<String, dynamic> attribution, {required AdaptyExternalAttributionProvider provider}) {
+  Future<void> updateExternalAttribution(
+    Map<String, dynamic> attribution, {
+    required AdaptyExternalAttributionProvider provider,
+  }) {
     updateExternalAttributionCalls += 1;
     lastAttribution = attribution;
     lastAttributionProvider = provider;

--- a/example/test/profile_screen_test.dart
+++ b/example/test/profile_screen_test.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../lib/app/app_controller.dart';
-import '../lib/app/user_manager.dart';
-import '../lib/ui/adaptive.dart';
-import '../lib/ui/profile_screen.dart';
+import 'package:adapty_recipes/app/app_controller.dart';
+import 'package:adapty_recipes/app/user_manager.dart';
+import 'package:adapty_recipes/ui/adaptive.dart';
+import 'package:adapty_recipes/ui/profile_screen.dart';
 
 void main() {
   late AppController controller;

--- a/test/custom_flow_layout_test.dart
+++ b/test/custom_flow_layout_test.dart
@@ -55,7 +55,7 @@ void main() {
     expect(request, isNot(contains('custom_layout_id')));
   });
 
-  test('embedded creation params trim an unknown custom grid id and forward the safe area flag', () {
+  test('embedded creation params trim the custom grid id and forward the safe area flag', () {
     final params = buildFlowPlatformViewCreationParams(
       flow: _flow(),
       customLayoutId: ' unknown custom id ',


### PR DESCRIPTION
Follow-ups from a code review of #194/#198/#203 that missed the merges.

- Example: the locale port in #194 was a compile-time null, so the demo always rendered the default localization and the locale test compared null with null. The profile screen now edits the requested locale (AppConstants.flowLocale is the initial value); both the modal and the embedded view use it. _publishIdentityTransition also resets isSendingAttribution.
- Tests: controller tests answer the SDK method channel, so presentFlowModally completes instead of failing on present(); new cases cover the in-flight attribution flag, a second tap, and an identity switch mid-request. Tests import the example via package: URIs.
- Docs: AGENTS.md names AdaptyUIFlowsEventsObserver; CHANGELOG 4.1.0-dev.1 says the iOS pin waits for the release cut (Android is already exact), lists that iOS still tracks dev, and files the custom-layout Android note under native dependencies; README documents flowLocale and the attribution row.